### PR TITLE
remove and randomize admin_password

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ To be used with a local map of tags.
 module "jenkins_ha_agents" {
   source = "neiman-marcus/jenkins-ha-agents/aws"
 
-  admin_password  = "foo"
   bastion_sg_name = "bastion-sg"
   domain_name     = "foo.io."
 
@@ -56,7 +55,6 @@ Note: It is better to use a template file, but the template data sources below i
 module "jenkins_ha_agents" {
   source = "neiman-marcus/jenkins-ha-agents/aws"
 
-  admin_password = "foo"
   agent_max      = 6
   agent_min      = 2
 
@@ -149,7 +147,6 @@ EOF
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| admin_password | The master admin password. Used to bootstrap and login to the master. Also pushed to ssm parameter store for posterity. | string | `N/A` | yes |
 | agent_max | The maximum number of agents to run in the agent ASG. | int | `6` | no |
 | agent_min | The minimum number of agents to run in the agent ASG. | int | `2` | no |
 | ami_name | The name of the amzn2 ami. Used for searching for AMI id. | string | `amzn2-ami-hvm-2.0.*-x86_64-gp2`| no |

--- a/main.tf
+++ b/main.tf
@@ -728,7 +728,7 @@ data "template_file" "master_runcmd" {
   vars = {
     admin_password  = var.admin_password
     aws_region      = var.region
-    jenkins_version = var.jenkins_version
+    jenkins_version = random_string.admin_password.keepers.jenkins_version
     master_storage  = aws_efs_file_system.master_efs.id
   }
 }
@@ -835,6 +835,16 @@ resource "aws_ssm_parameter" "admin_password" {
   name        = "${var.ssm_parameter}${var.password_ssm_parameter}"
   description = "${var.application}-admin-password"
   type        = "SecureString"
-  value       = var.admin_password
+  value       = random_string.admin_password.result
   overwrite   = true
 }
+
+resource "random_string" "admin_password" {
+  length = 16
+  special = true
+  keepers = {
+    jenkins_version = var.jenkins_version
+  }
+}
+
+

--- a/variables.tf
+++ b/variables.tf
@@ -1,7 +1,3 @@
-variable "admin_password" {
-  description = "The master admin password. Used to bootstrap and login to the master. Also pushed to ssm parameter store for posterity."
-}
-
 variable "agent_max" {
   description = "The maximum number of agents to run in the agent ASG."
   default     = 6


### PR DESCRIPTION
Randomize the Jenkins admin password, Also changes the password each time the Jenkins version is changed.

This idea is to access Jenkins via OneLogin SAML, and only access via this password as part of a break glass process