### PR TITLE
CLOUD-8947: terraform 1.x syntax

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -467,8 +467,8 @@ resource "aws_autoscaling_policy" "agent_scale_down_policy" {
 
 resource "aws_autoscaling_group" "master_asg" {
   depends_on = [
-    "aws_efs_mount_target.mount_target_a",
-    "aws_efs_mount_target.mount_target_b",
+    aws_efs_mount_target.mount_target_a,
+    aws_efs_mount_target.mount_target_b,
   ]
 
   max_size = 1

--- a/main.tf
+++ b/main.tf
@@ -93,9 +93,9 @@ resource "aws_lb" "lb" {
 
   tags = merge(
     var.tags,
-    map(
-      "Name", "${var.application}-lb"
-    )
+    tomap({
+      "Name" = "${var.application}-lb"
+    })
   )
 }
 
@@ -565,9 +565,9 @@ resource "aws_security_group" "master_sg" {
 
   tags = merge(
     var.tags,
-    map(
-      "Name", "${var.application}-master-sg"
-    )
+    tomap({
+      "Name" = "${var.application}-master-sg"
+    })
   )
 }
 

--- a/main.tf
+++ b/main.tf
@@ -207,7 +207,7 @@ resource "aws_cloudwatch_metric_alarm" "agent_cpu_alarm" {
 
 resource "aws_autoscaling_group" "agent_asg" {
   depends_on = [
-    "aws_autoscaling_group.master_asg",
+    aws_autoscaling_group.master_asg,
   ]
 
   max_size = var.agent_max

--- a/main.tf
+++ b/main.tf
@@ -796,9 +796,9 @@ resource "aws_security_group" "master_storage_sg" {
 
   tags = merge(
     var.tags,
-    map(
-      "Name", "${var.application}-master-storage-sg"
-    )
+    tomap({
+      "Name" = "${var.application}-master-storage-sg"
+    })
   )
 }
 

--- a/main.tf
+++ b/main.tf
@@ -127,9 +127,9 @@ resource "aws_security_group" "lb_sg" {
 
   tags = merge(
     var.tags,
-    map(
-      "Name", "${var.application}-lb-sg"
-    )
+    tomap({
+      "Name" = "${var.application}-lb-sg"
+    })
   )
 }
 
@@ -283,9 +283,9 @@ resource "aws_security_group" "agent_sg" {
 
   tags = merge(
     var.tags,
-    map(
-      "Name", "${var.application}-agent-sg"
-    )
+    tomap({
+      "Name" = "${var.application}-agent-sg"
+    })
   )
 }
 
@@ -316,9 +316,9 @@ EOF
 
   tags = merge(
     var.tags,
-    map(
-      "Name", "${var.application}-agent-iam-role",
-    )
+    tomap({
+      "Name" = "${var.application}-agent-iam-role",
+    })
   )
 }
 
@@ -389,9 +389,9 @@ resource "aws_cloudwatch_log_group" "agent_logs" {
 
   tags = merge(
     var.tags,
-    map(
-      "Name", "${var.application}-agent-logs"
-    )
+    tomap({
+      "Name" = "${var.application}-agent-logs"
+    })
   )
 }
 
@@ -598,9 +598,9 @@ EOF
 
   tags = merge(
     var.tags,
-    map(
-      "Name", "${var.application}-master-iam-role"
-    )
+    tomap({
+      "Name" = "${var.application}-master-iam-role"
+    })
   )
 }
 
@@ -666,9 +666,9 @@ resource "aws_cloudwatch_log_group" "master_logs" {
 
   tags = merge(
     var.tags,
-    map(
-      "Name", "${var.application}-master-logs"
-    )
+    tomap({
+      "Name" = "${var.application}-master-logs"
+      })
   )
 }
 
@@ -745,9 +745,9 @@ resource "aws_efs_file_system" "master_efs" {
 
   tags = merge(
     var.tags,
-    map(
-      "Name", "${var.application}-master-efs"
-    )
+    tomap({
+      "Name" = "${var.application}-master-efs"
+    })
   )
 }
 
@@ -821,9 +821,9 @@ resource "aws_lb_target_group" "master_tg" {
 
   tags = merge(
     var.tags,
-    map(
-      "Name", "${var.application}-master-tg"
-    )
+    tomap({
+      "Name" = "${var.application}-master-tg"
+    })
   )
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -88,7 +88,7 @@ variable "password_ssm_parameter" {
 
 variable "private_cidr_ingress" {
   description = "Private IP address cidr ranges allowed access to the instances."
-  type        = "list"
+  type        = list(string)
   default     = ["10.0.0.0/8"]
 }
 
@@ -102,7 +102,7 @@ variable "private_subnet_name_az2" {
 
 variable "public_cidr_ingress" {
   description = "Public IP address cidr ranges allowed access to the instances."
-  type        = "list"
+  type        = list(string)
   default     = ["0.0.0.0/0"]
 }
 
@@ -124,7 +124,7 @@ variable "region" {
 
 variable "spot_price" {
   description = "The spot price map for each instance type."
-  type        = "map"
+  type        = map(string)
 
   default = {
     "t2.micro"  = "0.0116"
@@ -150,7 +150,7 @@ variable "swarm_version" {
 
 variable "tags" {
   description = "tags to define locally, and interpolate into the tags in this module."
-  type        = "map"
+  type        = map(string)
 }
 
 variable "vpc_name" {


### PR DESCRIPTION
Fixes syntax deprecation errors and warnings when running with Terraform 1.x.